### PR TITLE
Fix telemetry event being sent to telemetry emitter process instead of test process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [0.1.1] - 2023-06-05
+### Fixed
+- Fix telemetry event being sent to telemetry emitter process instead of test process(#1).
+
+## [0.1.0] - 2023-06-02
+### Added
+- Initial implementation

--- a/lib/telemetry_test.ex
+++ b/lib/telemetry_test.ex
@@ -37,7 +37,7 @@ defmodule TelemetryTest do
   """
   @doc since: "0.1.0"
   def telemetry_listen(%{telemetry_listen: event, test: test_name}) when is_event(event) do
-    attach_helper(test_name, event, :this_is_a_config, &__MODULE__.__send_to_self_handler__/4)
+    attach_helper(test_name, event, self(), &__MODULE__.__send_to_self_handler__/4)
   end
 
   def telemetry_listen(%{telemetry_listen: {event_name, telemetry_listen_fn}, test: test_name})
@@ -93,8 +93,8 @@ defmodule TelemetryTest do
 
   @doc false
   # This function is only public to avoid a warning about optimization
-  def __send_to_self_handler__(event, measurements, metadata, _config) do
+  def __send_to_self_handler__(event, measurements, metadata, config_test_pid) do
     args = %{event: event, measurements: measurements, metadata: metadata}
-    send(self(), {:telemetry_event, args})
+    send(config_test_pid, {:telemetry_event, args})
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule TelemetryTest.MixProject do
   def project do
     [
       app: :telemetry_test,
-      version: "0.1.0",
+      version: "0.1.1",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/telemetry_test_test.exs
+++ b/test/telemetry_test_test.exs
@@ -26,6 +26,25 @@ defmodule TelemetryTestTest do
       assert context.foo == :bar
     end
 
+    @tag telemetry_listen: [:sample, :event]
+    test "sends telemetry event to test process even when code runs outside test process",
+         context do
+      spawn(fn ->
+        :telemetry.execute([:sample, :event], %{sample_measurement: true}, %{
+          sample_metadata: true
+        })
+      end)
+
+      assert_receive {:telemetry_event,
+                      %{
+                        event: [:sample, :event],
+                        measurements: %{sample_measurement: true},
+                        metadata: %{sample_metadata: true}
+                      }}
+
+      assert context.foo == :bar
+    end
+
     @tag telemetry_listen: {[:sample, :event], &__MODULE__.test_callback/1}
     test "executes given function after test run", context do
       :telemetry.execute([:sample, :event], %{sample_measurement: true}, %{sample_metadata: true})


### PR DESCRIPTION
Since we were sending the message to `self()` inside the handler it means that when the telemetry event is emitted by other process the test wouldn't receive the event message. This PR aims to always send the event message to the test process.